### PR TITLE
Trailing alignment fixed

### DIFF
--- a/Sources/WrappingStack/Helpers/TightHeightGeometryReader.swift
+++ b/Sources/WrappingStack/Helpers/TightHeightGeometryReader.swift
@@ -4,11 +4,16 @@ import SwiftUI
 
 @available(iOS 14, macOS 11, *)
 struct TightHeightGeometryReader<Content: View>: View {
+    var alignment: Alignment
     @State private var height: CGFloat = 0
 
     var content: (GeometryProxy) -> Content
     
-    init(@ViewBuilder content: @escaping (GeometryProxy) -> Content) {
+    init(
+        alignment: Alignment = .topLeading,
+        @ViewBuilder content: @escaping (GeometryProxy) -> Content
+    ) {
+        self.alignment = alignment
         self.content = content
     }
     
@@ -20,6 +25,7 @@ struct TightHeightGeometryReader<Content: View>: View {
                         self.height = size.height
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: alignment)
         }
         .frame(height: height)
     }

--- a/Sources/WrappingStack/WrappingHStack.swift
+++ b/Sources/WrappingStack/WrappingHStack.swift
@@ -159,8 +159,7 @@ struct WrappingHStack_Previews: PreviewProvider {
             }
         }
         .padding()
-        .frame(maxWidth: .infinity)
-//        .frame(width: 300)
+        .frame(width: 300)
         .background(Color.white)
     }
 }

--- a/Sources/WrappingStack/WrappingHStack.swift
+++ b/Sources/WrappingStack/WrappingHStack.swift
@@ -87,7 +87,7 @@ public struct WrappingHStack<Data: RandomAccessCollection, ID: Hashable, Content
     
     public var body: some View {
         if calculatesSizesKeys.isSuperset(of: idsForCalculatingSizes) {
-            TightHeightGeometryReader { geometry in
+            TightHeightGeometryReader(alignment: alignment) { geometry in
                 let splitted = splitIntoLines(maxWidth: geometry.size.width)
                 
                 // All sizes are known
@@ -147,6 +147,7 @@ struct WrappingHStack_Previews: PreviewProvider {
     static var previews: some View {
         WrappingHStack(
             id: \.self,
+            alignment: .trailing,
             horizontalSpacing: 8,
             verticalSpacing: 8
         ) {
@@ -158,7 +159,8 @@ struct WrappingHStack_Previews: PreviewProvider {
             }
         }
         .padding()
-        .frame(width: 300)
+        .frame(maxWidth: .infinity)
+//        .frame(width: 300)
         .background(Color.white)
     }
 }


### PR DESCRIPTION
A fix for this issue: https://github.com/diniska/swiftui-wrapping-stack/issues/4

The issue caused by `GeometryReader` aligning to the leading edge by default