### PR TITLE
Deployment target 11+ and tvOS availability

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,9 @@ import PackageDescription
 let package = Package(
     name: "WrappingStack",
     platforms: [
-        .iOS(.v9),
+        .iOS(.v11),
         .watchOS(.v6),
-        .tvOS(.v13),
+        .tvOS(.v11),
         .macOS(.v10_10)
     ],
     products: [

--- a/Sources/WrappingStack/Helpers/SizeReader.swift
+++ b/Sources/WrappingStack/Helpers/SizeReader.swift
@@ -2,14 +2,14 @@
 
 import SwiftUI
 
-@available(iOS 14, macOS 11, *)
+@available(iOS 14, tvOS 14, macOS 11, *)
 extension View {
     func onSizeChange(perform action: @escaping (CGSize) -> ()) -> some View {
         modifier(SizeReader(onChange: action))
     }
 }
 
-@available(iOS 14, macOS 11, *)
+@available(iOS 14, tvOS 14, macOS 11, *)
 private struct SizeReader: ViewModifier {
     var onChange: (CGSize) -> ()
     
@@ -25,7 +25,7 @@ private struct SizeReader: ViewModifier {
     }
 }
 
-@available(iOS 14, macOS 11, *)
+@available(iOS 14, tvOS 14, macOS 11, *)
 private struct SizePreferenceKey: PreferenceKey {
     static var defaultValue: CGSize = .zero
     static func reduce(value: inout CGSize, nextValue: () -> CGSize) {}

--- a/Sources/WrappingStack/Helpers/TightHeightGeometryReader.swift
+++ b/Sources/WrappingStack/Helpers/TightHeightGeometryReader.swift
@@ -2,7 +2,7 @@
 
 import SwiftUI
 
-@available(iOS 14, macOS 11, *)
+@available(iOS 14, tvOS 14, macOS 11, *)
 struct TightHeightGeometryReader<Content: View>: View {
     var alignment: Alignment
     @State private var height: CGFloat = 0

--- a/Sources/WrappingStack/WrappingHStack.swift
+++ b/Sources/WrappingStack/WrappingHStack.swift
@@ -3,7 +3,7 @@
 import SwiftUI
 
 /// An HStack that grows vertically when single line overflows
-@available(iOS 14, macOS 11, *)
+@available(iOS 14, tvOS 14, macOS 11, *)
 public struct WrappingHStack<Data: RandomAccessCollection, ID: Hashable, Content: View>: View {
     
     public let data: Data
@@ -105,7 +105,7 @@ public struct WrappingHStack<Data: RandomAccessCollection, ID: Hashable, Content
     }
 }
 
-@available(iOS 14, macOS 11, *)
+@available(iOS 14, tvOS 14, macOS 11, *)
 extension WrappingHStack where ID == Data.Element.ID, Data.Element: Identifiable {
     /// Creates a new WrappingHStack
     ///
@@ -130,7 +130,7 @@ extension WrappingHStack where ID == Data.Element.ID, Data.Element: Identifiable
 
 #if DEBUG
 
-@available(iOS 14, macOS 11, *)
+@available(iOS 14, tvOS 14, macOS 11, *)
 struct WrappingHStack_Previews: PreviewProvider {
     static var previews: some View {
         WrappingHStack(

--- a/Sources/WrappingStack/WrappingHStack.swift
+++ b/Sources/WrappingStack/WrappingHStack.swift
@@ -142,14 +142,13 @@ struct WrappingHStack_Previews: PreviewProvider {
             ForEach(["Cat 🐱", "Dog 🐶", "Sun 🌞", "Moon 🌕", "Tree 🌳"], id: \.self) { element in
                 Text(element)
                     .padding()
-                    .background(Color.gray.opacity(0.1))
+                    .background(Color.secondary.opacity(0.2))
                     .cornerRadius(6)
                     .fixedSize()
             }
         }
         .padding()
         .frame(width: 300)
-        .background(Color.white)
     }
 }
 


### PR DESCRIPTION
1. Xcode 14 minimal deployment target is iOS 11 so I've bumped it in Package.swift file as well.
2. I see no reason why this component is not available on tvOS. Deployment target has been changed to tvOS 11 and tvOS 14 has been added to `@available` attributes
3. Tuned preview a bit to look good in both color schemes and all supported platforms